### PR TITLE
Update exceptions.py

### DIFF
--- a/dirhunt/exceptions.py
+++ b/dirhunt/exceptions.py
@@ -2,7 +2,9 @@
 import functools
 import sys
 import traceback
+import ssl
 
+ssl.match_hostname = lambda cert, hostname: True
 
 class DirHuntError(Exception):
     body = ''


### PR DESCRIPTION
Will be generated when using dirhunt for ip with https certificate
ssl.CertificateError: hostname XXXX doesn't match either of
Anomaly. For example dirhunt https://42.186.69.33/venus/projects/_/users