### PR TITLE
Add false 404 report option

### DIFF
--- a/dirhunt/crawler_url.py
+++ b/dirhunt/crawler_url.py
@@ -96,6 +96,7 @@ class CrawlerUrl(object):
             self.exists = True
         self.add_self_directories(True if (not self.maybe_rewrite() and self.exists) else None,
                                   'directory' if not self.maybe_rewrite() else None)
+        self.identify_false_404(resp, text)
         self.close()
         return self
 
@@ -141,3 +142,9 @@ class CrawlerUrl(object):
             'type': self.type,
             'exists': self.exists,
         }
+
+    def identify_false_404(self, resp, text):
+        if resp.status_code == 404 and self.exists is None:
+            if '404' not in text.lower():
+                self.exists = True
+                self.flags.add('not_found.fake')

--- a/dirhunt/processors.py
+++ b/dirhunt/processors.py
@@ -225,6 +225,8 @@ class ProcessNotFound(ProcessBase):
 
     def process(self, text, soup=None):
         self.search_index_files()
+        if self.crawler_url.exists:
+            self.crawler_url.flags.add('not_found.fake')
 
     @classmethod
     def is_applicable(cls, request, text, crawler_url, soup):

--- a/dirhunt/tests/test_processors.py
+++ b/dirhunt/tests/test_processors.py
@@ -88,6 +88,16 @@ class TestProcessNotFound(CrawlerTestBase, unittest.TestCase):
         process = ProcessNotFound(None, crawler_url)
         str(process)
 
+    def test_identify_false_404(self):
+        crawler_url = self.get_crawler_url()
+        process = ProcessNotFound(None, crawler_url)
+        resp = requests.Response()
+        resp.status_code = 404
+        text = "This is a test page without the 404 keyword."
+        process.crawler_url.identify_false_404(resp, text)
+        self.assertTrue(process.crawler_url.exists)
+        self.assertIn('not_found.fake', process.crawler_url.flags)
+
 
 class TestProcessCssStyleSheet(CrawlerTestBase, unittest.TestCase):
     css = 'body { background-image: url("img/foo.png") }'


### PR DESCRIPTION
Related to #42

Add functionality to report false 404 errors.

* Add `identify_false_404` method in `CrawlerUrl` class in `dirhunt/crawler_url.py` to identify false 404 errors.
* Update `start` method in `CrawlerUrl` class to call `identify_false_404`.
* Update `ProcessNotFound` class in `dirhunt/processors.py` to handle false 404 errors and set appropriate flags.
* Add tests in `dirhunt/tests/test_processors.py` to verify false 404 reporting functionality.

