### PR TITLE
feat: Detect CMS and print to console (closes #123)

### DIFF
--- a/dirhunt/cms.py
+++ b/dirhunt/cms.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""
+CMS detection for dirhunt.
+
+Each CMS entry contains one or more of these signature types:
+  - asset_paths   : substrings looked for inside asset/link src/href paths
+  - meta_names    : <meta name="..."> values (lowercased)
+  - meta_content  : <meta ...content="..."> value substrings (lowercased)
+  - html_comments : substrings searched in HTML comment nodes
+  - headers       : HTTP response header name→value substring pairs
+  - html_patterns : arbitrary substrings anywhere in the raw HTML text
+"""
+
+CMS_SIGNATURES = [
+    {
+        'name': 'WordPress',
+        'flag': 'wordpress',
+        'asset_paths': ['wp-content/', 'wp-includes/'],
+        'meta_names': ['generator'],
+        'meta_content': ['wordpress'],
+        'html_patterns': ['/wp-login.php', 'wp-embed.min.js'],
+    },
+    {
+        'name': 'Drupal',
+        'flag': 'drupal',
+        'asset_paths': ['/sites/default/files/', '/misc/drupal.js', '/core/misc/drupal.js'],
+        'meta_names': ['generator'],
+        'meta_content': ['drupal'],
+        'headers': {'X-Generator': 'drupal', 'X-Drupal-Cache': ''},
+        'html_patterns': ['Drupal.settings', 'drupal.org'],
+    },
+    {
+        'name': 'Joomla',
+        'flag': 'joomla',
+        'asset_paths': ['/media/jui/', '/media/system/js/', '/components/com_'],
+        'meta_names': ['generator'],
+        'meta_content': ['joomla'],
+        'html_patterns': ['/administrator/index.php'],
+    },
+    {
+        'name': 'Magento',
+        'flag': 'magento',
+        'asset_paths': ['/skin/frontend/', '/js/mage/', '/pub/static/frontend/'],
+        'meta_names': ['generator'],
+        'meta_content': ['magento'],
+        'html_patterns': ['Mage.Cookies', 'mage/cookies'],
+    },
+    {
+        'name': 'PrestaShop',
+        'flag': 'prestashop',
+        'asset_paths': ['/themes/default-bootstrap/', '/modules/ps_'],
+        'html_patterns': ['prestashop', 'PrestaShop'],
+        'headers': {'X-Powered-By': 'prestashop'},
+    },
+    {
+        'name': 'TYPO3',
+        'flag': 'typo3',
+        'asset_paths': ['/typo3/', '/typo3conf/'],
+        'meta_content': ['typo3'],
+        'html_patterns': ['typo3temp', 'typo3conf'],
+    },
+    {
+        'name': 'Shopify',
+        'flag': 'shopify',
+        'asset_paths': ['cdn.shopify.com'],
+        'html_patterns': ['Shopify.theme', 'shopify_pay'],
+        'meta_content': ['shopify'],
+    },
+    {
+        'name': 'Wix',
+        'flag': 'wix',
+        'asset_paths': ['static.wixstatic.com', 'wix-warmup-data'],
+        'html_patterns': ['wixsite.com', 'X-Wix-Published-Version'],
+    },
+    {
+        'name': 'Squarespace',
+        'flag': 'squarespace',
+        'asset_paths': ['static.squarespace.com', 'squarespace-cdn.com'],
+        'html_patterns': ['Static.SQUARESPACE_CONTEXT', 'squarespace.com'],
+    },
+    {
+        'name': 'Ghost',
+        'flag': 'ghost',
+        'asset_paths': ['/ghost/'],
+        'meta_content': ['ghost'],
+        'html_patterns': ['ghost.io', 'content="Ghost '],
+    },
+]
+
+
+def detect_cms_from_asset(asset_path, current_flags):
+    """
+    Check a single asset URL path against all CMS asset_path signatures.
+
+    :param asset_path: str — the URL path of a discovered asset
+    :param current_flags: set — existing flags on the CrawlerUrl
+    :return: dict|None — the matching CMS entry, or None
+    """
+    for cms in CMS_SIGNATURES:
+        if cms['flag'] in current_flags:
+            continue
+        for pattern in cms.get('asset_paths', []):
+            if pattern in asset_path:
+                return cms
+    return None
+
+
+def detect_cms_from_html(text, soup, response_headers, current_flags):
+    """
+    Check raw HTML text, BeautifulSoup meta tags, and response headers
+    against all CMS signatures.
+
+    :param text: str — raw response body
+    :param soup: BeautifulSoup — parsed document
+    :param response_headers: dict-like — HTTP response headers
+    :param current_flags: set — existing flags on the CrawlerUrl
+    :return: list[dict] — all newly matched CMS entries
+    """
+    matched = []
+    for cms in CMS_SIGNATURES:
+        if cms['flag'] in current_flags:
+            continue
+
+        # 1. Raw HTML patterns
+        for pattern in cms.get('html_patterns', []):
+            if pattern in text:
+                matched.append(cms)
+                break  # no need to check further for this CMS
+        else:
+            # 2. <meta name="generator" content="..."> and similar
+            if soup:
+                for meta in soup.find_all('meta'):
+                    name = (meta.attrs.get('name') or '').lower()
+                    content = (meta.attrs.get('content') or '').lower()
+                    if name in cms.get('meta_names', []) and \
+                            any(p in content for p in cms.get('meta_content', [])):
+                        matched.append(cms)
+                        break
+
+            # 3. HTTP response headers
+            for header_name, header_value in cms.get('headers', {}).items():
+                actual = (response_headers.get(header_name) or '').lower()
+                if header_value == '' and actual:
+                    # presence-only check
+                    matched.append(cms)
+                    break
+                if header_value and header_value in actual:
+                    matched.append(cms)
+                    break
+
+    return matched

--- a/dirhunt/processors.py
+++ b/dirhunt/processors.py
@@ -11,6 +11,7 @@ if sys.version_info < (3,):
 from bs4 import Comment
 from colorama import Fore, Back
 
+from dirhunt.cms import detect_cms_from_asset, detect_cms_from_html
 from dirhunt.colors import status_code_colors
 from dirhunt.crawler_url import CrawlerUrl
 from dirhunt.url import Url, full_url_address
@@ -79,6 +80,7 @@ class ProcessBase(object):
         # TODO: procesar otras cosas (css, etc.)
         self.crawler_url = crawler_url
         self.keywords_found = set()
+        self.cms_detected = set()  # human-readable CMS names found on this page
 
     def search_index_files(self):
         if self.crawler_url.type not in ['directory', None]:
@@ -138,6 +140,9 @@ class ProcessBase(object):
         if self.keywords_found:
             body += colored('\n    Keywords found: ', Fore.BLUE)
             body += ', '.join(self.keywords_found)
+        if self.cms_detected:
+            body += colored('\n    CMS detected: ', Fore.GREEN)
+            body += colored(', '.join(sorted(self.cms_detected)), Fore.LIGHTGREEN_EX)
         return body
 
     def json(self):
@@ -145,6 +150,7 @@ class ProcessBase(object):
             'processor_class': '{}'.format(self.__class__.__name__),
             'status_code': self.status_code,
             'crawler_url': self.crawler_url.json(),
+            'cms_detected': sorted(self.cms_detected),
             'line': str(self),
         }
 
@@ -292,7 +298,18 @@ class ProcessHtmlRequest(ProcessBase):
         self.search_keywords(text)
         self.assets(soup)
         self.links(soup)
+        self._detect_cms_from_document(text, soup)
         self.search_index_files()
+
+    def _detect_cms_from_document(self, text, soup):
+        """Run full-document CMS detection (meta tags, headers, HTML patterns)."""
+        response_headers = {}
+        if self.crawler_url.resp is not None:
+            response_headers = self.crawler_url.resp.headers
+        matched = detect_cms_from_html(text, soup, response_headers, self.crawler_url.flags)
+        for cms in matched:
+            self.crawler_url.flags.add(cms['flag'])
+            self.cms_detected.add(cms['name'])
 
     def links(self, soup):
         links = [full_url_address(link.attrs.get('href'), self.crawler_url.url)
@@ -326,13 +343,18 @@ class ProcessHtmlRequest(ProcessBase):
 
     def analyze_asset(self, asset):
         """
+        Inspect a discovered asset URL for CMS fingerprints.
 
         :type asset: Url
         """
-        if 'wordpress' not in self.crawler_url.flags and 'wp-content' in asset.path:
-            self.crawler_url.flags.update({'wordpress'})
-            # Override type always except for root path
-            self.crawler_url.type = 'rewrite' if self.crawler_url.type != 'directory' else 'directory'
+        cms = detect_cms_from_asset(asset.path, self.crawler_url.flags)
+        if cms:
+            self.crawler_url.flags.add(cms['flag'])
+            self.cms_detected.add(cms['name'])
+            # Preserve existing type-override logic from the original WordPress check
+            self.crawler_url.type = (
+                'rewrite' if self.crawler_url.type != 'directory' else 'directory'
+            )
             self.crawler_url.depth -= 1
 
     @classmethod

--- a/dirhunt/tests/test_cms.py
+++ b/dirhunt/tests/test_cms.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+"""Tests for CMS detection (dirhunt/cms.py) and its integration in processors."""
+import unittest
+
+import requests
+import requests_mock
+from bs4 import BeautifulSoup
+
+from dirhunt.cms import detect_cms_from_asset, detect_cms_from_html
+from dirhunt.processors import ProcessHtmlRequest
+from dirhunt.tests.base import CrawlerTestBase
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for dirhunt/cms.py
+# ---------------------------------------------------------------------------
+
+class TestDetectCmsFromAsset(unittest.TestCase):
+    """detect_cms_from_asset — path-based fingerprinting."""
+
+    def test_detects_wordpress_via_wp_content(self):
+        cms = detect_cms_from_asset('/wp-content/themes/mytheme/style.css', set())
+        self.assertIsNotNone(cms)
+        self.assertEqual(cms['flag'], 'wordpress')
+
+    def test_detects_wordpress_via_wp_includes(self):
+        cms = detect_cms_from_asset('/wp-includes/js/jquery.js', set())
+        self.assertIsNotNone(cms)
+        self.assertEqual(cms['flag'], 'wordpress')
+
+    def test_detects_drupal_via_sites_default(self):
+        cms = detect_cms_from_asset('/sites/default/files/image.png', set())
+        self.assertIsNotNone(cms)
+        self.assertEqual(cms['flag'], 'drupal')
+
+    def test_detects_joomla_via_media_jui(self):
+        cms = detect_cms_from_asset('/media/jui/js/jquery.min.js', set())
+        self.assertIsNotNone(cms)
+        self.assertEqual(cms['flag'], 'joomla')
+
+    def test_detects_magento_via_pub_static(self):
+        cms = detect_cms_from_asset('/pub/static/frontend/Magento/luma/en_US/mage/bootstrap.js', set())
+        self.assertIsNotNone(cms)
+        self.assertEqual(cms['flag'], 'magento')
+
+    def test_returns_none_for_unknown_path(self):
+        cms = detect_cms_from_asset('/assets/img/logo.png', set())
+        self.assertIsNone(cms)
+
+    def test_skips_already_flagged_cms(self):
+        # WordPress already in flags — should not be returned again
+        cms = detect_cms_from_asset('/wp-content/themes/x/style.css', {'wordpress'})
+        self.assertIsNone(cms)
+
+    def test_detects_shopify_via_cdn(self):
+        cms = detect_cms_from_asset('https://cdn.shopify.com/s/files/1/0001/theme.js', set())
+        self.assertIsNotNone(cms)
+        self.assertEqual(cms['flag'], 'shopify')
+
+
+class TestDetectCmsFromHtml(unittest.TestCase):
+    """detect_cms_from_html — meta tag, header and pattern based."""
+
+    def _soup(self, html):
+        return BeautifulSoup(html, 'html.parser')
+
+    # --- WordPress ---
+    def test_detects_wordpress_via_generator_meta(self):
+        html = '<html><head><meta name="generator" content="WordPress 6.2"></head></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('wordpress', flags)
+
+    def test_detects_wordpress_via_html_pattern(self):
+        html = '<html><body><script src="/wp-login.php"></script></body></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('wordpress', flags)
+
+    # --- Drupal ---
+    def test_detects_drupal_via_generator_meta(self):
+        html = '<html><head><meta name="generator" content="Drupal 9 (https://www.drupal.org)"></head></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('drupal', flags)
+
+    def test_detects_drupal_via_x_generator_header(self):
+        html = '<html></html>'
+        headers = {'X-Generator': 'Drupal 9 (https://www.drupal.org)'}
+        matches = detect_cms_from_html(html, self._soup(html), headers, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('drupal', flags)
+
+    def test_detects_drupal_via_drupal_cache_header(self):
+        html = '<html></html>'
+        headers = {'X-Drupal-Cache': 'HIT'}
+        matches = detect_cms_from_html(html, self._soup(html), headers, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('drupal', flags)
+
+    # --- Joomla ---
+    def test_detects_joomla_via_generator_meta(self):
+        html = '<html><head><meta name="generator" content="Joomla! - Open Source Content Management"></head></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('joomla', flags)
+
+    # --- Shopify ---
+    def test_detects_shopify_via_html_pattern(self):
+        html = '<html><body><script>Shopify.theme = {}</script></body></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        flags = {m['flag'] for m in matches}
+        self.assertIn('shopify', flags)
+
+    # --- No false positive ---
+    def test_returns_empty_for_plain_html(self):
+        html = '<html><head><title>Hello</title></head><body><p>World</p></body></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        self.assertEqual(matches, [])
+
+    def test_skips_already_flagged(self):
+        html = '<html><head><meta name="generator" content="WordPress 6.2"></head></html>'
+        matches = detect_cms_from_html(html, self._soup(html), {}, {'wordpress'})
+        flags = {m['flag'] for m in matches}
+        self.assertNotIn('wordpress', flags)
+
+    def test_detects_multiple_cms_in_one_page(self):
+        """Edge case: a page that bizarrely triggers two CMS fingerprints."""
+        html = ('<html><head>'
+                '<meta name="generator" content="WordPress 6.2">'
+                '<meta name="generator" content="Joomla! CMS">'
+                '</head></html>')
+        matches = detect_cms_from_html(html, self._soup(html), {}, set())
+        flags = {m['flag'] for m in matches}
+        # WordPress detected first via meta; Joomla may also be present
+        self.assertIn('wordpress', flags)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for ProcessHtmlRequest
+# ---------------------------------------------------------------------------
+
+class TestProcessHtmlRequestCmsDetection(CrawlerTestBase, unittest.TestCase):
+    """Ensure CMS flags and names reach the processor layer."""
+
+    def _make_response(self, html, url='http://domain.com/path/'):
+        with requests_mock.mock() as m:
+            m.register_uri('GET', url, text=html,
+                           headers={'Content-Type': 'text/html'}, status_code=200)
+            return requests.get(url)
+
+    def _make_processor(self, html):
+        resp = self._make_response(html)
+        crawler_url = self.get_crawler_url()
+        crawler_url.resp = resp  # attach so headers are available
+        return ProcessHtmlRequest(resp, crawler_url)
+
+    def test_wordpress_flag_set_via_asset_path(self):
+        html = ('<html><head>'
+                '<link rel="stylesheet" href="/wp-content/themes/x/style.css">'
+                '</head><body></body></html>')
+        proc = self._make_processor(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        proc.process(html, soup)
+        self.assertIn('wordpress', proc.crawler_url.flags)
+        self.assertIn('WordPress', proc.cms_detected)
+
+    def test_drupal_flag_set_via_meta_generator(self):
+        html = ('<html><head>'
+                '<meta name="generator" content="Drupal 9 (https://www.drupal.org)">'
+                '</head><body></body></html>')
+        proc = self._make_processor(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        proc.process(html, soup)
+        self.assertIn('drupal', proc.crawler_url.flags)
+        self.assertIn('Drupal', proc.cms_detected)
+
+    def test_joomla_flag_set_via_asset(self):
+        html = ('<html><head>'
+                '<script src="/media/jui/js/jquery.min.js"></script>'
+                '</head><body></body></html>')
+        proc = self._make_processor(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        proc.process(html, soup)
+        self.assertIn('joomla', proc.crawler_url.flags)
+        self.assertIn('Joomla', proc.cms_detected)
+
+    def test_cms_name_printed_in_str(self):
+        html = ('<html><head>'
+                '<link href="/wp-content/themes/x/style.css" rel="stylesheet">'
+                '</head><body></body></html>')
+        proc = self._make_processor(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        proc.process(html, soup)
+        self.assertIn('WordPress', str(proc))
+
+    def test_cms_name_in_json(self):
+        html = ('<html><head>'
+                '<link href="/wp-content/themes/x/style.css" rel="stylesheet">'
+                '</head><body></body></html>')
+        proc = self._make_processor(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        proc.process(html, soup)
+        self.assertIn('WordPress', proc.json()['cms_detected'])
+
+    def test_no_cms_detected_on_plain_page(self):
+        html = '<html><head><title>Hello</title></head><body><p>World</p></body></html>'
+        proc = self._make_processor(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        proc.process(html, soup)
+        self.assertEqual(proc.cms_detected, set())
+        self.assertNotIn('CMS detected', str(proc))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Resolves #123 — detect the CMS (WordPress, Drupal, Joomla, etc.)
and print it to the console during a scan.

## Changes

### New file: `dirhunt/cms.py`
A data-driven CMS signature registry with detection via:
- Asset URL paths (e.g. `/wp-content/`, `/sites/default/files/`)
- `<meta name="generator">` tags
- HTTP response headers (`X-Generator`, `X-Drupal-Cache`, etc.)
- Raw HTML patterns (`Drupal.settings`, `Shopify.theme`, etc.)

CMSes covered: WordPress, Drupal, Joomla, Magento, PrestaShop,
TYPO3, Shopify, Wix, Squarespace, Ghost.
New CMSes can be added by inserting a single dict — no code changes.

### Modified: `dirhunt/processors.py`
- `ProcessBase`: added `cms_detected` set; prints green
  `CMS detected: <name>` line; includes list in JSON output
- `ProcessHtmlRequest.analyze_asset`: replaced single hardcoded
  WordPress check with generalised `detect_cms_from_asset()`
- `ProcessHtmlRequest.process`: added `_detect_cms_from_document()`
  call for meta/header/pattern-based detection

### New file: `dirhunt/tests/test_cms.py`
24 tests — all passing — covering unit and integration scenarios.

## Console Output Example
```
[200] https://example.com/ (HTML document)
    CMS detected: WordPress
```